### PR TITLE
Add CSV loading pytest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 scikit-learn
 matplotlib
 seaborn
+pytest

--- a/tests/test_csv_loading.py
+++ b/tests/test_csv_loading.py
@@ -1,0 +1,8 @@
+import pandas as pd
+from pathlib import Path
+
+def test_csv_columns():
+    csv_path = Path(__file__).resolve().parent.parent / 'testfile.csv'
+    df = pd.read_csv(csv_path, encoding='utf-8-sig')
+    assert list(df.columns) == ['Daily Return', '7-Day MA']
+


### PR DESCRIPTION
## Summary
- add a pytest to validate CSV loading with utf-8-sig
- include pytest in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6867392308c4832e98cc9d27921a4ccf