### PR TITLE
Handle UTF-8 BOM in uploaded CSV

### DIFF
--- a/app.py
+++ b/app.py
@@ -79,7 +79,9 @@ with tab2:
 
     if uploaded_file is not None:
         #load uploaded file
-        historical_data = pd.read_csv(uploaded_file)
+        historical_data = pd.read_csv(uploaded_file, encoding="utf-8-sig")
+        # Remove potential BOM from column names
+        historical_data.rename(columns=lambda x: x.replace('\ufeff', ''), inplace=True)
 
         #display uploaded file
         st.write("Uploaded Historical Data:")


### PR DESCRIPTION
## Summary
- ensure BOM encoded headers load correctly by passing `encoding="utf-8-sig"`
- strip BOM characters from column names after reading the CSV

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686739208164832eb3814d0ce45bc300